### PR TITLE
Update OriginSettingsViewModel.kt

### DIFF
--- a/komelia-komf-extension/popup/src/wasmJsMain/kotlin/snd/komelia/OriginSettingsViewModel.kt
+++ b/komelia-komf-extension/popup/src/wasmJsMain/kotlin/snd/komelia/OriginSettingsViewModel.kt
@@ -30,10 +30,10 @@ class OriginSettingsViewModel {
     }
 
     fun onOriginAdd(origin: String) {
-        val redactedOrigin = buildString {
-            append(origin)
-            if (!origin.endsWith("/")) append("/")
-            if (!origin.endsWith('*')) append("*")
+        val redactedOrigin = when {
+            origin.endsWith("/*") -> origin
+            origin.endsWith("/") -> origin + "*"
+            else -> origin + "/*"
         }
 
         newOriginError.value = null


### PR DESCRIPTION
Resolve issue with extra * being added to end of URL when added to extension

I can not test this directly at the moment. But to my knowledge this should fix the issue of the extra * being added even when URL is properly set.