### PR TITLE
Auto-connect to komf when Komelia is served from a komf instance

### DIFF
--- a/komelia-db/wasm/src/wasmJsMain/kotlin/snd/komelia/db/settings/LocalStorageSettingsRepository.kt
+++ b/komelia-db/wasm/src/wasmJsMain/kotlin/snd/komelia/db/settings/LocalStorageSettingsRepository.kt
@@ -2,6 +2,7 @@ package snd.komelia.db.settings
 
 import io.github.snd_r.komelia.image.UpsamplingMode
 import kotlinx.browser.localStorage
+import kotlinx.browser.window
 import kotlinx.serialization.json.Json
 import org.w3c.dom.set
 import snd.komelia.db.AppSettings
@@ -50,9 +51,18 @@ class LocalStorageSettingsRepository {
     }
 
     fun getKomfSettings(): KomfSettings {
-        return localStorage.getItem(komfSettingsKey)
-            ?.let { json.decodeFromString<KomfSettings>(it) }
-            ?: KomfSettings()
+        val stored = localStorage.getItem(komfSettingsKey)
+            ?.let { runCatching { json.decodeFromString<KomfSettings>(it) }.getOrNull() }
+        if (stored != null) return stored
+
+        // When Komelia is served from a komf instance, auto-connect to that instance
+        // rather than defaulting to localhost:8085
+        val origin = window.location.origin
+        return if (origin.isNotBlank() && !origin.contains("localhost") && !origin.contains("127.0.0.1")) {
+            KomfSettings(enabled = true, remoteUrl = origin)
+        } else {
+            KomfSettings()
+        }
     }
 
     fun saveKomfSettings(settings: KomfSettings) {


### PR DESCRIPTION
## Summary

- When no komf settings exist in localStorage (first visit), `getKomfSettings()` now checks `window.location.origin` instead of always returning the hardcoded `localhost:8085` default
- If the page is served from a non-localhost origin (e.g. `http://192.168.1.141:8086`), it returns `KomfSettings(enabled = true, remoteUrl = origin)` — the user doesn't need to manually configure anything
- Localhost and 127.0.0.1 origins fall back to the original `KomfSettings()` default (disabled), so development setups are unaffected
- Uses `runCatching` when deserialising the stored JSON so a corrupted/legacy value doesn't crash and gracefully falls through to the origin logic

## Motivation

komf embeds a copy of the Komelia web app. When a user visits komf at e.g. `http://server:8086`, the embedded Komelia showed a "Failed to connect to komf" error because it tried to reach `localhost:8085` (the default), which resolves to the **user's machine**, not the server.

This required users to manually open Settings → Komf, toggle "Enabled", and type in the correct URL — every time on a new browser or after clearing storage.

Related: [snd-r/komf#295](https://github.com/Snd-R/komf/pull/295)

## Test plan

- [ ] Visit Komelia served from a remote komf instance (e.g. `http://192.168.1.x:8086`) with empty localStorage — connection should be established automatically
- [ ] Visit from `localhost:8086` — should still default to disabled (no auto-connect)
- [ ] Existing stored settings should be respected as before (no regression)